### PR TITLE
stats path

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,10 @@ stats:
   interval: 60
 # tenant to use for stats
   tenant: "graphite"
-# hostname to use
+# (optional) hostname to use if not specified system's hostname will be used
   hostname: "disthene-reader"
+# (optional) path prefix for stats metrics, default to ""
+  pathPrefix: ""
 # carbon server to send stats to
   carbonHost: "carbon.example.net"
 # carbon port to send stats to

--- a/config/disthene-reader.yaml.sample
+++ b/config/disthene-reader.yaml.sample
@@ -34,5 +34,6 @@ stats:
   interval: 60
   tenant: "graphite"
   hostname: "disthene-1a"
+  pathPrefix: ""
   carbonHost: "carbon.example.net"
   carbonPort: 2003

--- a/src/main/java/net/iponweb/disthene/reader/config/StatsConfiguration.java
+++ b/src/main/java/net/iponweb/disthene/reader/config/StatsConfiguration.java
@@ -10,6 +10,7 @@ public class StatsConfiguration {
     private int interval;
     private String tenant;
     private String hostname;
+    private String pathPrefix;
     private String carbonHost;
     private int carbonPort;
 
@@ -20,6 +21,7 @@ public class StatsConfiguration {
         } catch (UnknownHostException e) {
             hostname = "unknown";
         }
+        pathPrefix = "";
     }
 
     public int getInterval() {
@@ -46,6 +48,15 @@ public class StatsConfiguration {
         this.hostname = hostname;
     }
 
+    public String getPathPrefix() {
+        return pathPrefix;
+    }
+
+    public void setPathPrefix(String pathPrefix) {
+        // remove right-trailing dot
+        this.pathPrefix = pathPrefix.endsWith(".") ? pathPrefix.replaceAll("\\.+\\z", "") : pathPrefix;
+    }
+
     public String getCarbonHost() {
         return carbonHost;
     }
@@ -62,12 +73,21 @@ public class StatsConfiguration {
         this.carbonPort = carbonPort;
     }
 
+    public String getPath() {
+        if (pathPrefix.isEmpty()) {
+            return hostname;
+        } else {
+            return pathPrefix + "." + hostname;
+        }
+    }
+
     @Override
     public String toString() {
         return "StatsConfiguration{" +
                 "interval=" + interval +
                 ", tenant='" + tenant + '\'' +
                 ", hostname='" + hostname + '\'' +
+                ", pathPrefix='" + pathPrefix + '\'' +
                 ", carbonHost='" + carbonHost + '\'' +
                 ", carbonPort=" + carbonPort +
                 '}';

--- a/src/main/java/net/iponweb/disthene/reader/graphite/evaluation/TargetEvaluator.java
+++ b/src/main/java/net/iponweb/disthene/reader/graphite/evaluation/TargetEvaluator.java
@@ -53,7 +53,6 @@ public class TargetEvaluator {
     public TimeSeries getEmptyTimeSeries(long from, long to) {
         Long now = System.currentTimeMillis() * 1000;
         Long effectiveTo = Math.min(to, now);
-
         Rollup bestRollup = metricService.getRollup(from);
         Long effectiveFrom = (from % bestRollup.getRollup()) == 0 ? from : from + bestRollup.getRollup() - (from % bestRollup.getRollup());
         effectiveTo = effectiveTo - (effectiveTo % bestRollup.getRollup());

--- a/src/main/java/net/iponweb/disthene/reader/handler/RenderHandler.java
+++ b/src/main/java/net/iponweb/disthene/reader/handler/RenderHandler.java
@@ -103,12 +103,8 @@ public class RenderHandler implements DistheneReaderHandler {
             statsService.incTimedOutRequests(parameters.getTenant());
             response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE);
         } catch (EvaluationException | LogarithmicScaleNotAllowed e) {
-            // TODO: distinguish the bad request (bad params, non-existent function,.. ) from internal error
-            // e.printStackTrace(System.out);
             throw e;
         } catch (Exception e) {
-            // TODO: distinguish the bad request (bad params, non-existent function,.. ) from internal error
-            // e.printStackTrace(System.out);
             logger.error(e);
             response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/net/iponweb/disthene/reader/service/metric/MetricService.java
+++ b/src/main/java/net/iponweb/disthene/reader/service/metric/MetricService.java
@@ -54,7 +54,6 @@ public class MetricService {
         // Calculate rollup etc
         Long now = System.currentTimeMillis() * 1000;
         Long effectiveTo = Math.min(to, now);
-
         Rollup bestRollup = getRollup(from);
         Long effectiveFrom = (from % bestRollup.getRollup()) == 0 ? from : from + bestRollup.getRollup() - (from % bestRollup.getRollup());
         effectiveTo = effectiveTo - (effectiveTo % bestRollup.getRollup());
@@ -123,7 +122,6 @@ public class MetricService {
         // Calculate rollup etc
         Long now = System.currentTimeMillis() * 1000;
         Long effectiveTo = Math.min(to, now);
-
         Rollup bestRollup = getRollup(from);
         Long effectiveFrom = (from % bestRollup.getRollup()) == 0 ? from : from + bestRollup.getRollup() - (from % bestRollup.getRollup());
         effectiveTo = effectiveTo - (effectiveTo % bestRollup.getRollup());
@@ -214,7 +212,6 @@ public class MetricService {
 
         // Let's find a rollup that potentially can have all the data taking retention in account
         List<Rollup> survivals = new ArrayList<>();
-
         for (Rollup rollup : distheneReaderConfiguration.getReader().getRollups()) {
             if (now - rollup.getPeriod() * rollup.getRollup() <= from) {
                 survivals.add(rollup);

--- a/src/main/java/net/iponweb/disthene/reader/service/stats/StatsService.java
+++ b/src/main/java/net/iponweb/disthene/reader/service/stats/StatsService.java
@@ -108,20 +108,20 @@ public class StatsService {
                 totalThrottled += statsRecord.getThrottled();
                 totalTimedOutRequests += statsRecord.getTimedOutRequests();
 
-                dos.writeBytes(statsConfiguration.getHostname() + ".disthene-reader.tenants." + tenant + ".render_requests " + statsRecord.getRenderRequests() + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
-                dos.writeBytes(statsConfiguration.getHostname() + ".disthene-reader.tenants." + tenant + ".render_paths_read " + statsRecord.getRenderPathsRead() + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
-                dos.writeBytes(statsConfiguration.getHostname() + ".disthene-reader.tenants." + tenant + ".render_points_read " + statsRecord.getRenderPointsRead() + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
-                dos.writeBytes(statsConfiguration.getHostname() + ".disthene-reader.tenants." + tenant + ".paths_requests " + statsRecord.getPathsRequests() + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
-                dos.writeBytes(statsConfiguration.getHostname() + ".disthene-reader.tenants." + tenant + ".throttled " + statsRecord.getThrottled() + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
-                dos.writeBytes(statsConfiguration.getHostname() + ".disthene-reader.tenants." + tenant + ".timed_out_requests " + statsRecord.getTimedOutRequests() + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
+                dos.writeBytes(statsConfiguration.getPath() + ".disthene-reader.tenants." + tenant + ".render_requests " + statsRecord.getRenderRequests() + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
+                dos.writeBytes(statsConfiguration.getPath() + ".disthene-reader.tenants." + tenant + ".render_paths_read " + statsRecord.getRenderPathsRead() + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
+                dos.writeBytes(statsConfiguration.getPath() + ".disthene-reader.tenants." + tenant + ".render_points_read " + statsRecord.getRenderPointsRead() + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
+                dos.writeBytes(statsConfiguration.getPath() + ".disthene-reader.tenants." + tenant + ".paths_requests " + statsRecord.getPathsRequests() + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
+                dos.writeBytes(statsConfiguration.getPath() + ".disthene-reader.tenants." + tenant + ".throttled " + statsRecord.getThrottled() + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
+                dos.writeBytes(statsConfiguration.getPath() + ".disthene-reader.tenants." + tenant + ".timed_out_requests " + statsRecord.getTimedOutRequests() + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
             }
 
-            dos.writeBytes(statsConfiguration.getHostname() + ".disthene-reader.render_requests " + totalRenderRequests + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
-            dos.writeBytes(statsConfiguration.getHostname() + ".disthene-reader.render_paths_read " + totalRenderPathsRead + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
-            dos.writeBytes(statsConfiguration.getHostname() + ".disthene-reader.render_points_read " + totalRenderPointsRead + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
-            dos.writeBytes(statsConfiguration.getHostname() + ".disthene-reader.paths_requests " + totalPathsRequests + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
-            dos.writeBytes(statsConfiguration.getHostname() + ".disthene-reader.throttled " + totalThrottled + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
-            dos.writeBytes(statsConfiguration.getHostname() + ".disthene-reader.timed_out_requests " + totalTimedOutRequests + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
+            dos.writeBytes(statsConfiguration.getPath() + ".disthene-reader.render_requests " + totalRenderRequests + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
+            dos.writeBytes(statsConfiguration.getPath() + ".disthene-reader.render_paths_read " + totalRenderPathsRead + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
+            dos.writeBytes(statsConfiguration.getPath() + ".disthene-reader.render_points_read " + totalRenderPointsRead + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
+            dos.writeBytes(statsConfiguration.getPath() + ".disthene-reader.paths_requests " + totalPathsRequests + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
+            dos.writeBytes(statsConfiguration.getPath() + ".disthene-reader.throttled " + totalThrottled + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
+            dos.writeBytes(statsConfiguration.getPath() + ".disthene-reader.timed_out_requests " + totalTimedOutRequests + " " + timestamp + " " + statsConfiguration.getTenant() + "\n");
 
             dos.flush();
             connection.close();


### PR DESCRIPTION
Currently disthene push metrics to the path <hostname>.disthene...., having dozens of ip/hostnames (and rotating instance on daily basis) in the top-level introduces too much noise in our case. This PR enables to test custom path for stats metrics.

similar to: https://github.com/EinsamHauer/disthene/pull/24